### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ecomodeller


### PR DESCRIPTION
Adds a [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file to define who owns and is responsible for this repository.

When a pull request is opened, GitHub will automatically request a review from the code owner(s) listed in this file.